### PR TITLE
raise_exception should be raise_error, and sorted_by shouldn't be required

### DIFF
--- a/lib/table_setter/table.rb
+++ b/lib/table_setter/table.rb
@@ -99,8 +99,10 @@ module TableSetter
 
     # A convienence method to return the sort array for table setter.
     def sort_array
-      @data.sorted_by.inject([]) do |memo, (key, value)|
-        memo << [@data.columns.index(key), value == 'descending' ? 1 : 0]
+      if @data.sorted_by
+        @data.sorted_by.inject([]) do |memo, (key, value)|
+          memo << [@data.columns.index(key), value == 'descending' ? 1 : 0]
+        end
       end
     end
 

--- a/spec/table-setter_spec.rb
+++ b/spec/table-setter_spec.rb
@@ -96,8 +96,8 @@ describe TableSetter::Table, "with hard pagination" do
   end
 
   it 'should not paginate when given a bad value' do
-    lambda {@data.paginate!(-1)}.should raise_exception(ArgumentError)
-    lambda {@data.paginate!(10000000)}.should raise_exception(ArgumentError)
+    lambda {@data.paginate!(-1)}.should raise_error(ArgumentError)
+    lambda {@data.paginate!(10000000)}.should raise_error(ArgumentError)
   end
 
   it 'should handle first page' do

--- a/template/tables/example.yml
+++ b/template/tables/example.yml
@@ -15,6 +15,4 @@ table:
     -  Public Enforcement Documents
     style:
       Bank: 'text-align:left;'
-    sorted_by:
-      Closing Date: 'ascending'
   live: true


### PR DESCRIPTION
Two problems:

```
NoMethodError in 'TableSetter::Table with hard pagination should not paginate when given a bad value'
undefined method `raise_exception' for #<Spec::Example::ExampleGroup::Subclass_5:0x00000100cf8798>
spec/table-setter_spec.rb:99:in `block (2 levels) in <top (required)>'
```

The specs are not passing because raise_exception is undefined. Use raise_error.

```
#<NoMethodError: undefined method `inject' for nil:NilClass>
```

If you create a new table.yml and omit the sorted_by key, you will see the above error. This is confusing and frustrating for first-time users. Also, sorted_by should not be a required key.

I edited example.yml to show that the tests pass with my change to sort_array. Run the tests with the updated example.yml but with the old table.rb and the tests will fail.

Note that style is also currently a required key, but fixing that requires [fixing method_missing in table-fu](https://github.com/propublica/table-fu/pull/1).
