### PR TITLE
[modify] modified Rack gem version

### DIFF
--- a/README
+++ b/README
@@ -8,3 +8,15 @@ TableSetter is a Ruby app which provides an easy way to present CSVs hosted loca
   
   examples
   http://propublica.github.com/table-setter/documentation/tables/example/
+
+=
+Installation Note
+
+- Rack 2.x has not `rack/showexceptions` but `rack/show_exceptions`.
+    - cf. [Incorrect rack requirement for showexceptions file · Issue \#1055 · sinatra/sinatra](https://github.com/sinatra/sinatra/issues/1055)
+- so you must specify rack version '< 2.0.0' such as below (Gemfile)
+
+```Gemfile
+gem 'table_setter'
+gem 'rack', '< 2.0.0'
+```

--- a/table_setter.gemspec
+++ b/table_setter.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.summary = %q{A sinatra based app for rendering CSVs in custom HTML}
 
   gem.add_development_dependency %q<minitest>
-  gem.add_dependency %q<rack>
+  gem.add_dependency %q<rack>, '< 2.0.0'
   gem.add_dependency %q<thin>
   gem.add_dependency %q<table_fu>
   gem.add_dependency %q<sinatra>
@@ -30,4 +30,3 @@ Gem::Specification.new do |gem|
   gem.add_dependency %q<curb>
   gem.add_dependency %q<rdiscount>
 end
-


### PR DESCRIPTION
Hi! `table-setter` is beautiful product, thank you :)

btw, we must specify Rack gem version `< 2.0.0`. Because of changing name from showexception to show_exception in Rack `>= 2.0.0`.

### for example
#### not specify Rack version

```bash
$ bundle install
Fetching rack 2.0.4
Installing rack 2.0.4
$ bundle exec table-setter --help
Traceback (most recent call last):
	5: from /home/takiya/table_setter/vendor/bundle/ruby/2.5.0/bin/table-setter:25:in `<main>'
	4: from /home/takiya/table_setter/vendor/bundle/ruby/2.5.0/bin/table-setter:25:in `load'
	3: from /home/takiya/table_setter/vendor/bundle/ruby/2.5.0/gems/table_setter-0.2.12/bin/table-setter:5:in `<top (required)>'
	2: from /home/takiya/table_setter/vendor/bundle/ruby/2.5.0/gems/table_setter-0.2.12/bin/table-setter:5:in `require'
	1: from /home/takiya/table_setter/vendor/bundle/ruby/2.5.0/gems/table_setter-0.2.12/lib/table_setter/command.rb:3:in `<top (required)>'
/home/takiya/table_setter/vendor/bundle/ruby/2.5.0/gems/table_setter-0.2.12/lib/table_setter/command.rb:3:in `require': cannot load such file -- rack/showexceptions (LoadError)
```
#### specify Rack version `< 2.0.0`

```bash
$ bundle install
Fetching rack 1.6.8
Installing rack 1.6.8
$ bundle exec table-setter --help
table-setter is a Sinatra application for rendering and processing CSVs from google docs into HTML.

Usage:
  table-setter COMMAND path/to/table-setter/assets OPTIONS

commands:
  start    run the development server, for deployment use config.ru
  install  copy the table-setter assets into the the directory
  build    statically build tables in the ./out/ directory

options:
    -p, --prefix PREFIX              url prefix for the export command
```

great.
